### PR TITLE
Performance improvements using System.Linq.Async and ReadOnlySpan

### DIFF
--- a/ChessComTournamentAggregator/ChessComTournamentAggregator.csproj
+++ b/ChessComTournamentAggregator/ChessComTournamentAggregator.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="LichessTournamentAggregator" Version="0.3.2" />
-    <PackageReference Include="System.Text.Json" Version="4.7.1" />
+    <PackageReference Include="System.Linq.Async" Version="4.1.1" />
   </ItemGroup>
 
 </Project>

--- a/ChessComTournamentAggregator/TournamentAggregator.cs
+++ b/ChessComTournamentAggregator/TournamentAggregator.cs
@@ -65,12 +65,11 @@ namespace ChessComTournamentAggregator
         {
             foreach (var item in tournamentIdsOrUrls)
             {
-                string tournamentId = item.Trim(new char[] { ' ', '/', '#' });
+                var tournamentId = item.AsSpan().Trim(new char[] { ' ', '/', '#' });
 
-                var reverse = string.Join("", tournamentId.Reverse());
-                tournamentId = string.Join("", reverse.Take(reverse.IndexOf("/")).Reverse());
+                tournamentId = tournamentId.Slice(tournamentId.LastIndexOf('/') + 1);
 
-                yield return new Uri($"https://api.chess.com/pub/tournament/{tournamentId}");
+                yield return new Uri($"https://api.chess.com/pub/tournament/{tournamentId.ToString()}");
             }
         }
 
@@ -138,7 +137,7 @@ namespace ChessComTournamentAggregator
             for (int i = 0; i < aggregatedResults.Count(); ++i)
             {
                 var result = aggregatedResults.ElementAt(i);
-                var columns = new string[] { (i +1).ToString(), result.Username, result.TotalScores.ToString(), aggregate(result.Scores) };
+                var columns = new string[] { (i + 1).ToString(), result.Username, result.TotalScores.ToString(), aggregate(result.Scores) };
                 sw.WriteLine(string.Join(separator, columns));
             }
 


### PR DESCRIPTION
* Reduce allocations by using `ReadOnlySpan` when handling strings
* Use` System.Linq.Async` LINQ extensions methods to properly handle `IAsyncEnumerable`.